### PR TITLE
Add Deno support

### DIFF
--- a/generate.d.ts
+++ b/generate.d.ts
@@ -1,0 +1,7 @@
+declare function generate(
+  outfile: string,
+  options?: { comment?: boolean; autoGlobalExports?: boolean },
+): {
+  entryPointFunctions: string;
+  globalAssignments: string | undefined;
+};

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,22 @@
+import type { PluginBuild } from "https://deno.land/x/esbuild@v0.12.15/mod.d.ts";
+// @deno-types="./generate.d.ts"
+import { generate } from "https://esm.sh/gas-entry-generator@2.1.0";
+
+export default {
+  name: "gas-plugin",
+  setup({ onEnd, initialOptions }: PluginBuild) {
+    onEnd(async () => {
+      if (initialOptions.outfile === undefined) {
+        throw Error(
+          '"outfile" is required. Note that "write: false" is not available.',
+        );
+      }
+      const code = await Deno.readTextFile(initialOptions.outfile);
+      const gas = generate(code, { comment: true });
+      await Deno.writeTextFile(
+        initialOptions.outfile,
+        `let global = this;\n${gas.entryPointFunctions}\n${code}`,
+      );
+    });
+  },
+};


### PR DESCRIPTION
Proposal Changes
- Enable to use the plugin from Deno
- TypeScript support (only Deno)
- throw Error if `outfile` is not found (only Deno)
  - It may be better to restrict `initialOptions` rather than throw Error
