### PR TITLE
Add export to GasPlugin for exporting its definition to dist/index.d.ts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import type { Plugin, PluginBuild } from 'esbuild'
 
-const GasPlugin: Plugin = {
+export const GasPlugin: Plugin = {
   name: 'gas-plugin',
   setup(build: PluginBuild) {
     const fs = require('fs')


### PR DESCRIPTION
Hello.

When I have written an esbuild configuration in TypeScript, I could not import { GasPlugin } from esbuild-gas-plugin package because of no types exported in dist/index.d.ts.
So I add export keyword to GasPlugin.

In my local machine, it seems to work.

Anyway, thank you for publish this plugin.
