### PR TITLE
use export instead of the Javascript way

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,4 +14,4 @@ const GasPlugin: Plugin = {
   }
 }
 
-exports.GasPlugin = GasPlugin
+export = { GasPlugin }


### PR DESCRIPTION
Hi,
I sent PR again.
I'm happy if you review this.

# The error I met 

In the case using TypeScript as a esbuild configuration language, an imported GasPlugin could not be resolved its type as Plugin.

```TypeScript
import * as esbuild from 'esbuild'
import { GasPlugin } from 'esbuild-gas-plugin'

esbuild.build({
    entryPoints: ['src/main.ts'],
    bundle: true,
    outfile: 'dist/Code.gs',  
    plugins: [GasPlugin]
})
```

This code made an error like below:
```console
% npm run build                 

> src@1.0.0 build
> ts-node ./esbuild.ts

/src/node_modules/ts-node/src/index.ts:820
    return new TSError(diagnosticText, diagnosticCodes);
           ^
TSError: ⨯ Unable to compile TypeScript:
esbuild.ts:2:10 - error TS2305: Module '"esbuild-gas-plugin"' has no exported member 'GasPlugin'.

2 import { GasPlugin } from 'esbuild-gas-plugin'
           ~~~~~~~~~

    at createTSError (/src/node_modules/ts-node/src/index.ts:820:12)
    at reportTSError (/src/node_modules/ts-node/src/index.ts:824:19)
    at getOutput (/src/node_modules/ts-node/src/index.ts:1014:36)
    at Object.compile (/src/node_modules/ts-node/src/index.ts:1322:43)
    at Module.m._compile (/src/node_modules/ts-node/src/index.ts:1454:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Object.require.extensions.<computed> [as .ts] (/src/node_modules/ts-node/src/index.ts:1458:12)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
  diagnosticCodes: [ 2305 ]
}
```

# Why this error occured?

I thought that tsc could not notice that GasPlugin is exported since the syntax `esports.GasPlugin = GasPlugin` is not for TypeScript but Javascript.

# What does this PR change?

There are small changes in compiled files since I changed `exports.GasPlugin = GasPlugin` to `export = { GasPlugin }` in `index.ts`.

**before:**
dist/index.d.ts
```TypeScript
export {}
```

dist/index.js
```Javascript
...
exports.GasPlugin = GasPlugin
```

**after:**
dist/index.d.ts
```TypeScript
import type { Plugin } from 'esbuild';
declare const _default: {
    GasPlugin: Plugin;
};
export = _default;
```

dist/index.js
```Javascript
...

module.exports = { GasPlugin };
```

These changes makes be able to resolved GasPlugin as a Plugin for esbuild in TypeScript.
The usage is no changes.

```TypeScript
import { GasPlugin } from 'esbuild-gas-plugin'
```