### PR TITLE
relax constraints on dependencies

### DIFF
--- a/build.ts
+++ b/build.ts
@@ -27,12 +27,12 @@ await build({
   mappings: {
     "https://deno.land/x/esbuild@v0.18.4/mod.d.ts": {
       name: "esbuild",
-      version: "0.18.4",
+      version: "^0.18.4",
       peerDependency: false,
     },
     "https://esm.sh/gas-entry-generator@2.1.0": {
       name: "gas-entry-generator",
-      version: "2.1.0",
+      version: "^2.1.0",
       peerDependency: false,
     },
   },


### PR DESCRIPTION
I recently wanted to bump a project of mine to the latest version of esbuild-gas-plugin. The newly declared dependencies (esbuild=0.18.4) forced my package manager (npm) to install another and older version of esbuild (I was using 0.18.16).

This PR mostly relaxes the constraints on the dependencies requested by this package.

I moved gas-entry-generator back to ^2.1.0 as it used to be the case before 0.7.0. And I put esbuild to ^0.18.4.