### PR TITLE
(multi entry points support) Added support for cases where outdir is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pnpm add -D esbuild-gas-plugin
 
 Add this to Your build script file, and paste `dist/bundle.js` to script editor.
 
-A simple example can be found in [here](https://github.com/mahaker/openapi-gas-example).
+A simple example can be found in [here](https://github.com/mahaker/esbuild-tutorial).
 
 ### Node
 
@@ -51,7 +51,7 @@ node build.js
 ```ts
 // build.ts
 import { build, stop } from 'https://deno.land/x/esbuild@v0.12.15/mod.js'
-import { GasPlugin } from 'npm:esbuild-gas-plugin@0.7.0'
+import { GasPlugin } from 'npm:esbuild-gas-plugin@0.9.0'
 import httpFetch from 'https://deno.land/x/esbuild_plugin_http_fetch@v1.0.2/index.js'
 
 await build({
@@ -69,4 +69,40 @@ and
 deno run --allow-read --allow-env --allow-run --allow-write build.ts
 # or
 deno run -A build.ts
+```
+
+### Multi Entry Points
+
+When using the strategy of specifying multiple files in esbuild's entryPoints to split the output into multiple files to avoid GAS's file size limitations, the entry point in GAS (referred to here as the prime entry point) needs to be consolidated into a single file.
+
+```ts
+// build.js for Node
+const { MultiEntryPointsGasPlugin } = require('esbuild-gas-plugin');
+
+require('esbuild').build({
+  entryPoints: ['src/**/*.ts'],
+  bundle: true,
+  outdir: 'dist',
+  plugins: [MultiEntryPointsGasPlugin({ primeEntryPointJs: "dist/index.js" })]
+}).catch((e) => {
+  console.error(e)
+  process.exit(1)
+})
+```
+
+or
+
+```ts
+// build.ts for Deno
+import { build, stop } from 'https://deno.land/x/esbuild@v0.12.15/mod.js'
+import { MultiEntryPointsGasPlugin } from 'npm:esbuild-gas-plugin@0.9.0'
+import httpFetch from 'https://deno.land/x/esbuild_plugin_http_fetch@v1.0.2/index.js'
+
+await build({
+  entryPoints: ['src/**/*.ts'],
+  bundle: true,
+  outdir: 'dist',
+  plugins: [httpFetch, MultiEntryPointsGasPlugin({ primeEntryPointJs: "dist/index.js" })]
+})
+stop()
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pnpm add -D esbuild-gas-plugin
 
 Add this to Your build script file, and paste `dist/bundle.js` to script editor.
 
-A simple example can be found in [here](https://github.com/mahaker/esbuild-tutorial).
+A simple example can be found in [here](https://github.com/mahaker/openapi-gas-example).
 
 ### Node
 

--- a/build.ts
+++ b/build.ts
@@ -13,7 +13,7 @@ await build({
   declaration: "separate",
   package: {
     name: "esbuild-gas-plugin",
-    version: "0.8.0",
+    version: "0.9.0",
     description: "esbuild plugin for Google Apps Script.",
     license: "MIT",
     author: "Hideaki Matsunami <carbon0409@gmail.com>",


### PR DESCRIPTION
Google Apps Script (GAS) has a file size limitation, which makes it prone to hitting this limit when bundling everything into a single file. To work around this, it's common to split the output into multiple files by specifying multiple files in the entryPoints option of esbuild or using a glob pattern like **/*.ts. Therefore, esbuild-gas-plugin needs to support cases where there are multiple output files.