### PR TITLE
Compatible with the Rhino Engine

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -44,13 +44,13 @@ export const GasPlugin = {
       if (jsBanner === undefined) {
         await Deno.writeTextFile(
           initialOptions.outfile,
-          `let global = this;\n${gas.entryPointFunctions}\n${code}`,
+          `var global = this;\n${gas.entryPointFunctions}\n${code}`,
         );
       } else {
         const bannerDeleted = await deleteBanner(code, jsBanner);
         await Deno.writeTextFile(
           initialOptions.outfile,
-          `${jsBanner}\nlet global = this;\n${gas.entryPointFunctions}${bannerDeleted}`,
+          `${jsBanner}\nvar global = this;\n${gas.entryPointFunctions}${bannerDeleted}`,
         );
       }
     });


### PR DESCRIPTION
Hi!

Currently i need to use the Rhino Engine on GAS because of the Jdbc service, you can read more [here](https://issuetracker.google.com/issues/149413841).

The problem is that this engine only supports ES5, so no `let` keyword. This PR just switches the `let` for `var`. It still works on the v8 engine, so i think there is no problem in changing it.